### PR TITLE
Fix: Terraform requires case sensitive env, however in windows environment, env are case insensitive. References nt instead of os when calling terraform to use case sensitive variables.

### DIFF
--- a/terraformx/terraformx.py
+++ b/terraformx/terraformx.py
@@ -2,6 +2,7 @@
 import sys
 import argparse
 import os
+import nt
 from dotenv import load_dotenv
 
 from terraformx.parser_init import *
@@ -78,12 +79,21 @@ Main commands:\n\
   import        Import existing infrastructure resources\n\
   rm            Remove a binding to an existing remote object without first destroying it"
 
+def load_nt_env(file_path):
+    with open(file_path, 'r') as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith('#'):
+                key, value = line.split('=', 1)
+                nt.environ[key] = value
+
 def default(args):
     print(top_level_help_message)
 
 def main():
     # export environmental variables from /config/.env if it exists
-    load_dotenv("config/.env") 
+    # load_dotenv("config/.env") 
+    load_nt_env("config/.env") 
 
     # top-level parser
     top_level_parser = argparse.ArgumentParser(description = "terraformx")

--- a/utils/terraform.py
+++ b/utils/terraform.py
@@ -231,9 +231,9 @@ def terraform_destroy_from_history():
 
 #         cwd = list_terraform_root_dir[DIR_NUMBER]
 
-#         # subprocess.Popen(APPLY_REFRESH_PROCESS, cwd=cwd).wait()
+#         # subprocess.Popen(APPLY_REFRESH_PROCESS, cwd=cwd, env=nt.environ).wait()
 
-#         p = subprocess.Popen(PLAN_REFRESH_PROCESS, cwd=cwd, stdout=subprocess.PIPE)
+#         p = subprocess.Popen(PLAN_REFRESH_PROCESS, cwd=cwd, stdout=subprocess.PIPE, env=nt.environ)
 
 #         out, err = p.communicate()
 

--- a/utils/terraform_commands.py
+++ b/utils/terraform_commands.py
@@ -1,4 +1,5 @@
 import os
+import nt
 import glob
 import subprocess
 
@@ -73,7 +74,7 @@ def terraform_init(cwd, CUSTOM_VAR_FILE="", set_stdin=None, set_stdout=None, set
     if len(CUSTOM_VAR_FILE) > 0:   
         init_process = [Terraform_commands_constants.TERRAFORM_PARSER, 'init', '-backend-config=%s' % CUSTOM_VAR_FILE]
 
-    subprocess.Popen(init_process, cwd=cwd, stdin=set_stdin, stdout=set_stdout, stderr=set_stderr).wait()
+    subprocess.Popen(init_process, cwd=cwd, stdin=set_stdin, stdout=set_stdout, stderr=set_stderr, env=nt.environ).wait()
 
 def terraform_apply(cwd, CUSTOM_VAR_FILE="", AUTO_APPROVE=False, github_action=False, set_stdin=None, set_stdout=None, set_stderr=None):
 
@@ -89,9 +90,9 @@ def terraform_apply(cwd, CUSTOM_VAR_FILE="", AUTO_APPROVE=False, github_action=F
         apply_process = [Terraform_commands_constants.TERRAFORM_PARSER, Terraform_commands_constants.APPLY, '-var-file=%s' % CUSTOM_VAR_FILE]
     
     if AUTO_APPROVE:
-        process = subprocess.Popen(apply_auto_approve_process, cwd=cwd, stdin=set_stdin, stdout=set_stdout, stderr=set_stderr).wait()
+        process = subprocess.Popen(apply_auto_approve_process, cwd=cwd, stdin=set_stdin, stdout=set_stdout, stderr=set_stderr, env=nt.environ).wait()
     else:
-        process = subprocess.Popen(apply_process, cwd=cwd, stdin=set_stdin, stdout=set_stdout, stderr=set_stderr).wait()
+        process = subprocess.Popen(apply_process, cwd=cwd, stdin=set_stdin, stdout=set_stdout, stderr=set_stderr, env=nt.environ).wait()
 
     if process == 1:
         # If the process experiences an error, skip the remaining commands
@@ -110,9 +111,9 @@ def terraform_destroy(cwd, CUSTOM_VAR_FILE="", AUTO_APPROVE=False, github_action
         destroy_process = [Terraform_commands_constants.TERRAFORM_PARSER, Terraform_commands_constants.DESTROY, '-var-file=%s' % CUSTOM_VAR_FILE]
 
     if AUTO_APPROVE:
-        process = subprocess.Popen(destroy_auto_approve_process, cwd=cwd, stdin=set_stdin, stdout=set_stdout, stderr=set_stderr).wait()
+        process = subprocess.Popen(destroy_auto_approve_process, cwd=cwd, stdin=set_stdin, stdout=set_stdout, stderr=set_stderr, env=nt.environ).wait()
     else:
-        process = subprocess.Popen(destroy_process, cwd=cwd, stdin=set_stdin, stdout=set_stdout, stderr=set_stderr).wait()
+        process = subprocess.Popen(destroy_process, cwd=cwd, stdin=set_stdin, stdout=set_stdout, stderr=set_stderr, env=nt.environ).wait()
 
     if process == 1:
         # If the process experiences an error, skip the remaining commands
@@ -124,14 +125,14 @@ def terraform_destroy(cwd, CUSTOM_VAR_FILE="", AUTO_APPROVE=False, github_action
 
 def terraform_output(cwd, set_stdin=None, set_stdout=None, set_stderr=None):
     tfvars_settings(cwd)
-    subprocess.Popen(Terraform_commands_constants.OUTPUT_PROCESS, cwd=cwd, stdin=set_stdin, stdout=set_stdout, stderr=set_stderr).wait()
+    subprocess.Popen(Terraform_commands_constants.OUTPUT_PROCESS, cwd=cwd, stdin=set_stdin, stdout=set_stdout, stderr=set_stderr, env=nt.environ).wait()
 
 def terraform_apply_refresh(cwd, AUTO_APPROVE=False):
     tfvars_settings(cwd)
     if AUTO_APPROVE:
-        process = subprocess.Popen(Terraform_commands_constants.APPLY_REFRESH_AUTO_APPROVE_PROCESS, cwd=cwd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).wait()
+        process = subprocess.Popen(Terraform_commands_constants.APPLY_REFRESH_AUTO_APPROVE_PROCESS, cwd=cwd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=nt.environ).wait()
     else:
-        process = subprocess.Popen(Terraform_commands_constants.APPLY_REFRESH_PROCESS, cwd=cwd).wait()
+        process = subprocess.Popen(Terraform_commands_constants.APPLY_REFRESH_PROCESS, cwd=cwd, env=nt.environ).wait()
 
     if process == 1:
         # If the process experiences an error, skip the remaining commands
@@ -139,13 +140,13 @@ def terraform_apply_refresh(cwd, AUTO_APPROVE=False):
 
 def terraform_plan_refresh(cwd):
     tfvars_settings(cwd)
-    return subprocess.Popen(Terraform_commands_constants.PLAN_REFRESH_PROCESS, cwd=cwd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+    return subprocess.Popen(Terraform_commands_constants.PLAN_REFRESH_PROCESS, cwd=cwd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, env=nt.environ)
 
 def terraform_apply_auto_approve_refresh(cwd):
     tfvars_settings(cwd)
     
     print("\nPerforming -apply-refresh to sync statefile and match the current provisioned state")
-    subprocess.Popen(Terraform_commands_constants.APPLY_REFRESH_AUTO_APPROVE_PROCESS, cwd=cwd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).wait()
+    subprocess.Popen(Terraform_commands_constants.APPLY_REFRESH_AUTO_APPROVE_PROCESS, cwd=cwd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=nt.environ).wait()
 
     # if input("\nEnter Y if you would you like to invoke \"terraform apply -refresh-only\" to the drifted Terraform Roots' state to match the current provisioned state: ").upper() == "Y":
     #     for index in range(len(drifted_terraform_roots)):
@@ -153,7 +154,7 @@ def terraform_apply_auto_approve_refresh(cwd):
 
     #         print("Invoking -refresh-only on %s" % os.path.basename(cwd))
     #         terraform_apply_refresh(cwd)
-            # subprocess.Popen(APPLY_REFRESH_PROCESS, cwd=cwd).wait()
+            # subprocess.Popen(APPLY_REFRESH_PROCESS, cwd=cwd, env=nt.environ).wait()
 
 def locate_terraform_root_directories(root_directory):
     
@@ -179,7 +180,7 @@ def terraform_import(cwd, stringvars):
 
     import_process = Terraform_commands_constants.IMPORT_PROCESS + stringvars
 
-    subprocess.Popen(import_process, cwd=cwd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).wait()
+    subprocess.Popen(import_process, cwd=cwd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=nt.environ).wait()
 
 def terraform_state_rm(cwd, stringvars):
 
@@ -189,4 +190,4 @@ def terraform_state_rm(cwd, stringvars):
 
     state_rm_process = Terraform_commands_constants.STATE_PROCESS + stringvars
 
-    subprocess.Popen(state_rm_process, cwd=cwd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).wait()
+    subprocess.Popen(state_rm_process, cwd=cwd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=nt.environ).wait()

--- a/utils/workflow.py
+++ b/utils/workflow.py
@@ -533,10 +533,10 @@ def workflow_terraform_apply(cwd, stage_targets, stage_name, AUTO_APPROVE=False,
 
     if AUTO_APPROVE:
         workflow_apply_auto_approve_target_process = Terraform_commands_constants.APPLY_AUTO_APPROVE_PROCESS + target_process
-        process = subprocess.Popen(workflow_apply_auto_approve_target_process, cwd=cwd).wait()
+        process = subprocess.Popen(workflow_apply_auto_approve_target_process, cwd=cwd, env=nt.environ).wait()
     else:
         workflow_apply_target_process = Terraform_commands_constants.APPLY_PROCESS + target_process
-        process = subprocess.Popen(workflow_apply_target_process, cwd=cwd).wait()
+        process = subprocess.Popen(workflow_apply_target_process, cwd=cwd, env=nt.environ).wait()
 
     if process == 1:
         # If the process experiences an error, skip the remaining commands
@@ -552,10 +552,10 @@ def workflow_terraform_destroy(cwd, stage_targets, stage_name, AUTO_APPROVE=Fals
 
     if AUTO_APPROVE:
         workflow_destroy_auto_approve_target_process = Terraform_commands_constants.DESTROY_AUTO_APPROVE_PROCESS + target_process
-        process = subprocess.Popen(workflow_destroy_auto_approve_target_process, cwd=cwd).wait()
+        process = subprocess.Popen(workflow_destroy_auto_approve_target_process, cwd=cwd, env=nt.environ).wait()
     else:
         workflow_destroy_target_process = Terraform_commands_constants.DESTROY_PROCESS + target_process
-        process = subprocess.Popen(workflow_destroy_target_process, cwd=cwd).wait()
+        process = subprocess.Popen(workflow_destroy_target_process, cwd=cwd, env=nt.environ).wait()
 
     if process == 1:
         # If the process experiences an error, skip the remaining commands
@@ -571,10 +571,10 @@ def workflow_terraform_apply_refresh(cwd, stage_targets, AUTO_APPROVE=False):
     
     if AUTO_APPROVE:
         workflow_apply_auto_approve_target_process = Terraform_commands_constants.APPLY_REFRESH_AUTO_APPROVE_PROCESS + ["-target=" + sub for sub in stage_targets]
-        process = subprocess.Popen(workflow_apply_auto_approve_target_process, cwd=cwd).wait()
+        process = subprocess.Popen(workflow_apply_auto_approve_target_process, cwd=cwd, env=nt.environ).wait()
     else:
         workflow_apply_target_process = Terraform_commands_constants.APPLY_REFRESH_PROCESS + ["-target=" + sub for sub in stage_targets]
-        process = subprocess.Popen(workflow_apply_target_process, cwd=cwd).wait()
+        process = subprocess.Popen(workflow_apply_target_process, cwd=cwd, env=nt.environ).wait()
 
     if process == 1:
         # If the process experiences an error, skip the remaining commands
@@ -586,7 +586,7 @@ def workflow_terraform_plan_refresh(cwd, stage_targets):
     tfvars_settings(cwd)
     
     workflow_apply_auto_approve_target_process = Terraform_commands_constants.PLAN_REFRESH_PROCESS + ["-target=" + sub for sub in stage_targets]
-    return subprocess.Popen(workflow_apply_auto_approve_target_process, cwd=cwd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+    return subprocess.Popen(workflow_apply_auto_approve_target_process, cwd=cwd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, env=nt.environ)
 
 def check_stages_errors(stages_errors):
 


### PR DESCRIPTION
…nment, env are case insensitive. References nt instead of os when calling terraform to use case sensitive variables.